### PR TITLE
Added and fixed reconnection support across the board

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,9 +10,19 @@ and this project adheres to `Semantic Versioning <http://semver.org/spec/v2.0.0.
 Unreleased
 ----------
 
+**Changed**
+
+* Changed behavior: Topics automatically reconnect when websockets is reconnected
+
 **Added**
 
 * Added blocking behavior to more ROS API methods: ``ros.get_nodes`` and ``ros.get_node_details``.
+* Added reconnection support to IronPython implementation of websockets
+* Added automatic topic reconnection support for both subscribers and publishers
+
+**Fixed**
+
+* Fixed reconnection issues on the Twisted/Autobahn-based implementation of websockets
 
 0.7.1
 ----------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+attrs>=19.2.0
 bumpversion>=0.5
 check-manifest>=0.36
 flake8

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ if sys.platform == "cli":
 else:
     requirements = [
         'autobahn>=17.10',
-        'twisted>=17.9'
+        'twisted>=17.9',
+        'attrs>=19.2.0'
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,7 @@ if sys.platform == "cli":
 else:
     requirements = [
         'autobahn>=17.10',
-        'twisted>=17.9',
-        'attrs>=19.2.0'
+        'twisted>=17.9'
     ]
 
 

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -84,6 +84,7 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
             self.once('ready', callback)
 
     def ready(self, proto):
+        self.resetDelay()
         self._proto = proto
         self.emit('ready', proto)
 

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -10,7 +10,6 @@ from autobahn.websocket.util import create_url
 from twisted.internet import defer
 from twisted.internet import reactor
 from twisted.internet import threads
-from twisted.internet.error import ConnectionDone
 from twisted.internet.protocol import ReconnectingClientFactory
 from twisted.python import log
 

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -29,7 +29,7 @@ class AutobahnRosBridgeProtocol(RosBridgeProtocol, WebSocketClientProtocol):
 
     def onOpen(self):
         LOGGER.info('Connection to ROS MASTER ready.')
-        self._manual_disconect = False
+        self._manual_disconnect = False
         self.factory.ready(self)
 
     def onMessage(self, payload, isBinary):
@@ -49,7 +49,7 @@ class AutobahnRosBridgeProtocol(RosBridgeProtocol, WebSocketClientProtocol):
         return self.sendMessage(payload, isBinary=False, fragmentSize=None, sync=False, doNotCompress=False)
 
     def send_close(self):
-        self._manual_disconect = True
+        self._manual_disconnect = True
         self.sendClose()
 
 
@@ -95,7 +95,7 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
         LOGGER.debug('Lost connection. Reason: %s', reason)
         self.emit('close', self._proto)
 
-        if not self._proto or (self._proto and self._proto._manual_disconect == False):
+        if not self._proto or (self._proto and self._proto._manual_disconnect == False):
             ReconnectingClientFactory.clientConnectionLost(self, connector, reason)
         self._proto = None
 

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -95,7 +95,7 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
         LOGGER.debug('Lost connection. Reason: %s', reason)
         self.emit('close', self._proto)
 
-        if self._proto and self._proto._manual_disconect == False:
+        if not self._proto or (self._proto and self._proto._manual_disconect == False):
             ReconnectingClientFactory.clientConnectionLost(self, connector, reason)
         self._proto = None
 

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -73,7 +73,7 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
             return
 
         LOGGER.info('Connection to ROS MASTER ready.')
-        self._manual_disconect = False
+        self._manual_disconnect = False
         self.factory.ready(self)
         self.factory.manager.call_in_thread(self.start_listening)
 
@@ -157,7 +157,7 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
                 try:
                     mre.Wait(self.factory.manager.cancellation_token)
                 except SystemError:
-                    LOGGER.debug('Cancelation detected on listening thread, exiting...')
+                    LOGGER.debug('Cancellation detected on listening thread, exiting...')
                     break
 
                 try:
@@ -176,7 +176,7 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
 
     def send_close(self):
         """Trigger the closure of the websocket indicating normal closing process."""
-        self._manual_disconect = True
+        self._manual_disconnect = True
 
         err_desc = ''
         err_code = WebSocketCloseStatus.NormalClosure
@@ -308,7 +308,7 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
         self.delay = self.initial_delay
 
     def _reconnect_if_needed(self):
-        if self.proto and self.proto._manual_disconect:
+        if self.proto and self.proto._manual_disconnect:
             return
 
         self.delay = min(self.delay * self.factor, self.max_delay)

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -235,7 +235,10 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
         Returns:
             bool: True if WebSocket is connected, False otherwise.
         """
-        return self.proto and self.proto.socket and self.proto.socket.State == WebSocketState.Open
+        if self.proto and self.proto.socket:
+            return self.proto.socket.State == WebSocketState.Open
+
+        return False
 
     def connect(self):
         """Establish WebSocket connection to the ROS server defined for this factory.

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -259,7 +259,7 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
 class CliRosBridgeClientFactory(EventEmitterMixin):
     """Factory to create instances of the ROS Bridge protocol built on top of .NET WebSockets."""
 
-    max_delay = 3600
+    max_delay = 3600.0
     initial_delay = 1.0
 
     # NOTE: The following factor was taken from Twisted's reconnecting factory:

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -232,8 +232,6 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
 
     def dispose(self, *args):
         """Dispose the resources held by this protocol instance, i.e. socket."""
-        self.factory.manager.terminate()
-
         if self.socket:
             self.socket.Dispose()
             self.socket = None

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -279,7 +279,6 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
         """
         LOGGER.debug('Started to connect...')
         socket = ClientWebSocket()
-        socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(5)
         connect_task = socket.ConnectAsync(
             self.url, self.manager.cancellation_token)
 

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -12,6 +12,7 @@ from System import Uri
 from System import UriBuilder
 from System.Net.WebSockets import ClientWebSocket
 from System.Net.WebSockets import WebSocketCloseStatus
+from System.Net.WebSockets import WebSocketError
 from System.Net.WebSockets import WebSocketMessageType
 from System.Net.WebSockets import WebSocketReceiveResult
 from System.Net.WebSockets import WebSocketState
@@ -34,6 +35,18 @@ RECEIVE_CHUNK_SIZE = 1024
 SEND_CHUNK_SIZE = 1024
 
 
+
+def _unwrap_exception(task):
+    exception = task.Exception
+    if exception.InnerException:
+        exception = exception.InnerException
+
+    if hasattr(exception, 'WebSocketErrorCode'):
+        return (exception.WebSocketErrorCode, exception.Message)
+
+    return (None, exception.Message)
+
+
 class CliRosBridgeProtocol(RosBridgeProtocol):
     """Implements the ROS Bridge protocol on top of CLI WebSockets.
 
@@ -54,21 +67,32 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
         """Triggered when the socket connection has been established.
 
         This will kick-start the listening thread."""
-        LOGGER.info('Connection to ROS MASTER ready.')
+        if task.IsFaulted:
+            err_code, err_desc = _unwrap_exception(task)
+            self.factory.client_connection_failed(self, err_code, err_desc)
+            return
 
+        LOGGER.info('Connection to ROS MASTER ready.')
+        self._manual_disconect = False
         self.factory.ready(self)
         self.factory.manager.call_in_thread(self.start_listening)
 
-    def receive_chunk_async(self, task_result, context):
+    def receive_chunk_async(self, task, context):
         """Handle the reception of a message chuck asynchronously."""
         try:
-            if task_result:
-                result = task_result.Result
+            if task:
+
+                if task.IsFaulted:
+                    err_code, err_desc = _unwrap_exception(task)
+                    self.factory.client_connection_lost(self, err_code, err_desc)
+                    return
+
+                result = task.Result
 
                 if result.MessageType == WebSocketMessageType.Close:
                     LOGGER.info('WebSocket connection closed: [Code=%s] Description=%s',
                                 result.CloseStatus, result.CloseStatusDescription)
-                    return self.send_close()
+                    return self._socket_close_frame_async()
                 else:
                     chunk = Encoding.UTF8.GetString(context['buffer'], 0, result.Count)
                     context['content'].append(chunk)
@@ -81,23 +105,22 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
 
                         # And signal the manual reset event
                         context['mre'].Set()
-                        return task_result
+                        return task
 
             # NOTE: We will enter the lock (Semaphore) at the start of receive
             # to make sure we're accessing the socket read/writes at most from
             # two threads, one for receiving and one for sending
-            if not task_result:
+            if not task:
                 self.semaphore.Wait(self.factory.manager.cancellation_token)
 
             receive_task = self.socket.ReceiveAsync(ArraySegment[Byte](
                 context['buffer']), self.factory.manager.cancellation_token)
             receive_task.ContinueWith.Overloads[Action[Task[WebSocketReceiveResult], object], object](
                 self.receive_chunk_async, context)
-
         except Exception:
             error_message = 'Exception on receive_chunk_async, processing will be aborted'
-            if task_result:
-                error_message += '; Task status: {}, Inner exception: {}'.format(task_result.Status, task_result.Exception)
+            if task:
+                error_message += '; Task status: {}, Inner exception: {}'.format(task.Status, task.Exception)
             LOGGER.exception(error_message)
             raise
 
@@ -139,21 +162,23 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
         finally:
             LOGGER.debug('Leaving the listening thread')
 
+    def _socket_close_frame_async(self):
+        err_code = WebSocketCloseStatus.NormalClosure
+        err_desc = ''
+        close_task = self.socket.CloseAsync(err_code, err_desc, CancellationToken.None)  # noqa: E999 (disable flake8 error, which incorrectly parses None as the python keyword)
+        self.factory.client_connection_lost(self, err_code, err_desc)
+        return close_task
+
     def send_close(self):
         """Trigger the closure of the websocket indicating normal closing process."""
-
+        self._manual_disconect = True
         if self.socket:
-            close_task = self.socket.CloseAsync(
-                WebSocketCloseStatus.NormalClosure, '', CancellationToken.None)  # noqa: E999 (disable flake8 error, which incorrectly parses None as the python keyword)
-            self.factory.emit('close', self)
-            # NOTE: Make sure reconnects are possible.
-            # Reconnection needs to be handled on a higher layer.
-            return close_task
+            return self._socket_close_frame_async()
 
-    def send_chunk_async(self, task_result, message_data):
+    def send_chunk_async(self, task, message_data):
         """Send a message chuck asynchronously."""
         try:
-            if not task_result:
+            if not task:
                 self.semaphore.Wait(self.factory.manager.cancellation_token)
 
             message_buffer, message_length, chunks_count, i = message_data
@@ -222,11 +247,19 @@ class CliRosBridgeProtocol(RosBridgeProtocol):
 class CliRosBridgeClientFactory(EventEmitterMixin):
     """Factory to create instances of the ROS Bridge protocol built on top of .NET WebSockets."""
 
+    max_delay = 3600
+    initial_delay = 1.0
+
+    # NOTE: The following factor was taken from Twisted's reconnecting factory:
+    # https://github.com/twisted/twisted/blob/6ac66416c0238f403a8dc1d42924fb3ba2a2a686/src/twisted/internet/protocol.py#L369
+    factor = 2.7182818284590451 # (math.e)
+
     def __init__(self, url, *args, **kwargs):
         super(CliRosBridgeClientFactory, self).__init__(*args, **kwargs)
         self._manager = CliEventLoopManager()
         self.proto = None
         self.url = url
+        self.delay = self.initial_delay
 
     @property
     def is_connected(self):
@@ -257,8 +290,41 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
 
         return connect_task
 
+    def reset_delay(self):
+        """
+        Call this method after a successful connection to reset the delay.
+        """
+        self.delay = self.initial_delay
+
+    def _reconnect_if_needed(self):
+        if self.proto and self.proto._manual_disconect:
+            return
+
+        self.delay = min(self.delay * self.factor, self.max_delay)
+        LOGGER.info('Connection manager will retry in {} seconds'.format(int(self.delay)))
+
+        self.manager.call_later(self.delay, self.connect)
+
+    def client_connection_lost(self, connector, reason_code, reason_description):
+        LOGGER.debug('Lost connection. Code: %s, Reason: %s', reason_code, reason_description)
+        self.emit('close', self.proto)
+        self._reconnect_if_needed()
+
+        if self.proto:
+            self.proto.dispose()
+            self.proto = None
+
+    def client_connection_failed(self, connector, reason_code, reason_description):
+        LOGGER.debug('Connection failed. Reason: %s', reason_description)
+        self._reconnect_if_needed()
+
+        if self.proto:
+            self.proto.dispose()
+            self.proto = None
+
     def ready(self, proto):
         self.proto = proto
+        self.reset_delay()
         self.emit('ready', proto)
 
     def on_ready(self, callback):

--- a/tests/test_ros.py
+++ b/tests/test_ros.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+
+import time
+
+import helpers
+
+from roslibpy import Ros
+
+
+def run_reconnect_does_not_trigger_on_client_close():
+    ros = Ros('127.0.0.1', 9090)
+    ros.run()
+
+    assert ros.is_connected == True, "ROS initially connected"
+    time.sleep(0.5)
+    ros.close()
+    time.sleep(0.5)
+
+    assert ros.is_connected == False, "Successful disconnect"
+    assert ros.is_connecting == False, "Not trying to re-connect"
+
+
+def test_reconnect_does_not_trigger_on_client_close():
+    helpers.run_as_process(run_reconnect_does_not_trigger_on_client_close)
+
+
+if __name__ == '__main__':
+    import logging
+
+    logging.basicConfig(level=logging.INFO, format='[%(thread)03d] %(asctime)-15s [%(levelname)s] %(message)s')
+    LOGGER = logging.getLogger('test')
+
+    run_reconnect_does_not_trigger_on_client_close()

--- a/tests/test_ros.py
+++ b/tests/test_ros.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import threading
 import time
 
 import helpers
@@ -13,8 +14,10 @@ def run_reconnect_does_not_trigger_on_client_close():
 
     assert ros.is_connected == True, "ROS initially connected"
     time.sleep(0.5)
+    event = threading.Event()
+    ros.on('close', lambda m: event.set())
     ros.close()
-    time.sleep(0.5)
+    event.wait(5)
 
     assert ros.is_connected == False, "Successful disconnect"
     assert ros.is_connecting == False, "Not trying to re-connect"

--- a/tests/test_ros.py
+++ b/tests/test_ros.py
@@ -12,15 +12,15 @@ def run_reconnect_does_not_trigger_on_client_close():
     ros = Ros('127.0.0.1', 9090)
     ros.run()
 
-    assert ros.is_connected == True, "ROS initially connected"
+    assert ros.is_connected, "ROS initially connected"
     time.sleep(0.5)
     event = threading.Event()
     ros.on('close', lambda m: event.set())
     ros.close()
     event.wait(5)
 
-    assert ros.is_connected == False, "Successful disconnect"
-    assert ros.is_connecting == False, "Not trying to re-connect"
+    assert not ros.is_connected, "Successful disconnect"
+    assert not ros.is_connecting, "Not trying to re-connect"
 
 
 def test_reconnect_does_not_trigger_on_client_close():


### PR DESCRIPTION
This PR addresses several existing and new issues related to reconnection support:
- [x] Communications layer:
   - [x] On CPython (twisted/autobahn implementation of websockets):
      - [x] Fix reconnection condition to actually make use of twisted's `ReconnectingClientFactory` (#29 and #44)
      - [x] Reset reconnection delay on successful reconnection
   - [x] On IronPython:
      - [x] Add reconnection support (which was missing altogether)
      - [x] Remove keep-alive packets to match the current settings of the twisted/autobahn implementation
      - [x] Fix early termination of manager loop on protocol disposal
- [x] **Behavior change!** Add reconnection behavior for subscriber and publisher topics. **Should we consider this a breaking change?**

This PR should also address #33.

I have tested this locally to a large extent, but I did not find a good way to write integration tests (it would involve killing the bridge process to test disconnect).