### PR TITLE
Add methods to edit the reconnection parameters

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -6,3 +6,4 @@ Authors
 * Gonzalo Casas <casas@arch.ethz.ch> `@gonzalocasas <https://github.com/gonzalocasas>`_
 * Mathias Lüdtke `@ipa-mdl <https://github.com/ipa-mdl>`_
 * Beverly Lytle `@beverlylytle <https://github.com/beverlylytle>`_
+* Alexis Jeandeau `@jeandeaual <https://github.com/jeandeaual>`_

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -117,6 +117,28 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
         url = host if port is None else create_url(host, port, is_secure)
         return url
 
+    @classmethod
+    def set_max_delay(cls, max_delay):
+        """Set the maximum delay in seconds for reconnecting to rosbridge (3600 seconds by default).
+
+        Args:
+            max_delay: The new maximum delay, in seconds.
+        """
+        LOGGER.debug('Updating max delay to {} seconds'.format(max_delay))
+        # See https://twistedmatrix.com/documents/19.10.0/api/twisted.internet.protocol.ReconnectingClientFactory.html
+        cls.maxDelay = max_delay
+
+    @classmethod
+    def set_initial_delay(cls, initial_delay):
+        """Set the initial delay in seconds for reconnecting to rosbridge (1 second by default).
+
+        Args:
+            initial_delay: The new initial delay, in seconds.
+        """
+        LOGGER.debug('Updating initial delay to {} seconds'.format(initial_delay))
+        # See https://twistedmatrix.com/documents/19.10.0/api/twisted.internet.protocol.ReconnectingClientFactory.html
+        cls.initialDelay = initial_delay
+
 
 class TwistedEventLoopManager(object):
     """Manage the main event loop using Twisted reactor.

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -139,6 +139,17 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
         # See https://twistedmatrix.com/documents/19.10.0/api/twisted.internet.protocol.ReconnectingClientFactory.html
         cls.initialDelay = initial_delay
 
+    @classmethod
+    def set_max_retries(cls, max_retries):
+        """Set the maximum number or connection retries when the rosbridge connection is lost (no limit by default).
+
+        Args:
+            max_retries: The new maximum number of retries.
+        """
+        LOGGER.debug('Updating max retries to {}'.format(max_retries))
+        # See https://twistedmatrix.com/documents/19.10.0/api/twisted.internet.protocol.ReconnectingClientFactory.html
+        cls.maxRetries = max_retries
+
 
 class TwistedEventLoopManager(object):
     """Manage the main event loop using Twisted reactor.

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -259,6 +259,7 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
 
     max_delay = 3600.0
     initial_delay = 1.0
+    max_retries = None
 
     # NOTE: The following factor was taken from Twisted's reconnecting factory:
     # https://github.com/twisted/twisted/blob/6ac66416c0238f403a8dc1d42924fb3ba2a2a686/src/twisted/internet/protocol.py#L369
@@ -270,6 +271,7 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
         self.proto = None
         self.url = url
         self.delay = self.initial_delay
+        self.retries = 0
 
     @property
     def is_connected(self):
@@ -309,6 +311,11 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
         if self.proto and self.proto._manual_disconnect:
             return
 
+        if self.max_retries is not None and (self.retries >= self.max_retries):
+            LOGGER.info('Abandonning after {} retries'.format(self.retries))
+            return
+
+        self.retries += 1
         self.delay = min(self.delay * self.factor, self.max_delay)
         LOGGER.info('Connection manager will retry in {} seconds'.format(int(self.delay)))
 
@@ -375,6 +382,16 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
         """
         LOGGER.debug('Updating initial delay to {} seconds'.format(max_delay))
         cls.initial_delay = initial_delay
+
+    @classmethod
+    def set_max_retries(cls, max_retries):
+        """Set the maximum number or connection retries when the rosbridge connection is lost (no limit by default).
+
+        Args:
+            max_retries: The new maximum number of retries.
+        """
+        LOGGER.debug('Updating max retries to {}'.format(max_retries))
+        cls.max_retries = max_retries
 
 
 class CliEventLoopManager(object):

--- a/src/roslibpy/comm/comm_cli.py
+++ b/src/roslibpy/comm/comm_cli.py
@@ -356,6 +356,26 @@ class CliRosBridgeClientFactory(EventEmitterMixin):
             builder = UriBuilder(scheme, host, port)
             return builder.Uri
 
+    @classmethod
+    def set_max_delay(cls, max_delay):
+        """Set the maximum delay in seconds for reconnecting to rosbridge (3600 seconds by default).
+
+        Args:
+            max_delay: The new maximum delay, in seconds.
+        """
+        LOGGER.debug('Updating max delay to {} seconds'.format(max_delay))
+        cls.max_delay = max_delay
+
+    @classmethod
+    def set_initial_delay(cls, initial_delay):
+        """Set the initial delay in seconds for reconnecting to rosbridge (1 second by default).
+
+        Args:
+            initial_delay: The new initial delay, in seconds.
+        """
+        LOGGER.debug('Updating initial delay to {} seconds'.format(max_delay))
+        cls.initial_delay = initial_delay
+
 
 class CliEventLoopManager(object):
     """Manage the main event loop using .NET threads.


### PR DESCRIPTION
Since version 1.0.0, reconnection to rosbridge is working very well. Thanks very much!

However there is no direct way to edit the initial and maximum delay (which can go up to 3600 seconds with Twisted) or the maximum number of retries (no limit by default with Twisted).

In this PR, I added several class methods to `CliRosBridgeClientFactory` and `AutobahnRosBridgeClientFactory`, which allows us to set the reconnection parameters before creating a `Ros` instance, as follows:

```python
from roslibpy import Ros
from roslibpy.comm import RosBridgeClientFactory

RosBridgeClientFactory.set_initial_delay(5)
RosBridgeClientFactory.set_max_delay(60)
RosBridgeClientFactory.set_max_retries(10)

ros = Ros(host='127.0.0.1', port=9090)
```

Implementing it as class methods seemed to be the only way, seeing how Twisted's `ReconnectingClientFactory` defines `maxDelay`, `initialDelay` and `maxRetries` as class variables (<https://github.com/twisted/twisted/blob/trunk/src/twisted/internet/protocol.py#L365>).

Please let me know if there's a better way to implement these settings.