### PR TITLE
Wait for both terminal status and result before marking a goal as finished

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,9 @@ Unreleased
 
 **Fixed**
 
+* Fixed #87 where a goal could be marked as terminal on result alone rather
+  than both result and status.
+
 **Deprecated**
 
 **Removed**

--- a/src/roslibpy/actionlib.py
+++ b/src/roslibpy/actionlib.py
@@ -150,13 +150,21 @@ class Goal(EventEmitterMixin):
 
     def _set_status(self, status):
         self.status = status
+        if self.is_finished:
+            self.wait_result.set()
 
     def _set_result(self, result):
         self.result = result
-        self.wait_result.set()
+        if self.is_finished:
+            self.wait_result.set()
 
     def _set_feedback(self, feedback):
         self.feedback = feedback
+
+    @property
+    def is_active(self):
+        return (self.status['status'] == GoalStatus.ACTIVE or
+                self.status['status'] == GoalStatus.PENDING)
 
     @property
     def is_finished(self):
@@ -165,7 +173,7 @@ class Goal(EventEmitterMixin):
         Returns:
             bool: True if finished, False otherwise.
         """
-        return self.result is not None
+        return self.result is not None and not self.is_active
 
 
 class ActionClient(EventEmitterMixin):

--- a/src/roslibpy/actionlib.py
+++ b/src/roslibpy/actionlib.py
@@ -120,6 +120,8 @@ class Goal(EventEmitterMixin):
         if result_callback:
             self.on('result', result_callback)
 
+        self.status = {'status': GoalStatus.PENDING}
+
         self.action_client.goal_topic.publish(self.goal_message)
         if timeout:
             self.action_client.ros.call_later(timeout, self._trigger_timeout)
@@ -163,6 +165,8 @@ class Goal(EventEmitterMixin):
 
     @property
     def is_active(self):
+        if self.status is None:
+            return False
         return (self.status['status'] == GoalStatus.ACTIVE or
                 self.status['status'] == GoalStatus.PENDING)
 
@@ -244,7 +248,6 @@ class ActionClient(EventEmitterMixin):
         goal = self.goals.get(goal_id, None)
 
         if goal:
-            goal.emit('status', message['status'])
             goal.emit('feedback', message['feedback'])
 
     def _on_result_message(self, message):
@@ -252,7 +255,6 @@ class ActionClient(EventEmitterMixin):
         goal = self.goals.get(goal_id, None)
 
         if goal:
-            goal.emit('status', message['status'])
             goal.emit('result', message['result'])
 
     def add_goal(self, goal):


### PR DESCRIPTION
This PR fixes #87 by waiting on both a result and terminal status before marking a goal as completed.

The behavior is a bit tricky to simulate from a testing perspective as it's a race so I didn't add any new tests, but I ensured it passes the current suite and works for my case in practice.

I did a few things here:

- Limited status updates to the status channel to give one source of truth for goal statuses rather than allowing feedback and result messages to also inject their own state.
- Wait on both a result object and a terminal status to mark an action as completed.
- Set the status of a goal to pending when it goes out over the wire so it is immediately marked as active.

Let me know if there are any questions and hope this helps!

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist
- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
