### PR TITLE
close #92: add host/port params to the command line interface

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Unreleased
 **Added**
 
 * Added function to set the default timeout value.
+* Added ROS host and port parameters to the command-line interface.
 
 **Changed**
 

--- a/src/roslibpy/__main__.py
+++ b/src/roslibpy/__main__.py
@@ -99,6 +99,8 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description='roslibpy command-line utility')
+    parser.add_argument('-r', '--ros-host', type=str, help='ROS host name or IP address', default='localhost')
+    parser.add_argument('-p', '--ros-port', type=int, help='ROS bridge port', default=9090)
 
     commands = parser.add_subparsers(help='commands')
     commands.dest = 'command'
@@ -186,7 +188,7 @@ def main():
 
     # Invoke
     args = parser.parse_args()
-    ros = roslibpy.Ros('localhost', 9090)
+    ros = roslibpy.Ros(args.ros_host, args.ros_port)
 
     try:
         ros.run()


### PR DESCRIPTION
Address #92 , adding both host and port params to the CLI.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
