### PR TITLE
Fix bug with action server (issue #95)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
           python -m pip install --no-cache-dir -r requirements-dev.txt
       - name: Set up docker containers
         run: |
-          docker build -t gramaziokohler/rosbridge ./docker
-          docker run -d -p 9090:9090 --name rosbridge gramaziokohler/rosbridge /bin/bash -c "roslaunch /integration-tests.launch"
+          docker build -t gramaziokohler/rosbridge:integration_tests ./docker
+          docker run -d -p 9090:9090 --name rosbridge gramaziokohler/rosbridge:integration_tests /bin/bash -c "roslaunch /integration-tests.launch"
           docker ps -a
       - name: Run linter
         run: |

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Authors
 * Beverly Lytle `@beverlylytle <https://github.com/beverlylytle>`_
 * Alexis Jeandeau `@jeandeaual <https://github.com/jeandeaual>`_
 * Hiroyuki Obinata `@obi-t4 <https://github.com/obi-t4>`_
+* Pedro Pereira `@MisterOwlPT <https://github.com/MisterOwlPT>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Unreleased
 
 **Changed**
 
+* Fixed bug with action client/server and now they work as expected.
 * Switched to ``black`` for python code formatting.
 * Fix incompatible settings between ``black`` and ``flake8``.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,14 @@
-FROM ros:kinetic
+FROM ros:noetic
 LABEL maintainer "Gonzalo Casas <casas@arch.ethz.ch>"
+
+SHELL ["/bin/bash","-c"]
 
 # Install rosbridge
 RUN apt-get update && apt-get install -y \
-    ros-kinetic-rosbridge-suite \
-    ros-kinetic-tf2-web-republisher \
-    ros-kinetic-ros-tutorials \
+    ros-noetic-rosbridge-suite \
+    ros-noetic-tf2-web-republisher \
+    ros-noetic-ros-tutorials \
+    ros-noetic-actionlib-tutorials \
     --no-install-recommends \
     # Clear apt-cache to reduce image size
     && rm -rf /var/lib/apt/lists/*
@@ -17,4 +20,4 @@ COPY ./integration-tests.launch /
 EXPOSE 9090
 
 ENTRYPOINT ["/ros_entrypoint.sh"]
-CMD ["/bin/bash"]
+CMD ["bash"]

--- a/src/roslibpy/actionlib.py
+++ b/src/roslibpy/actionlib.py
@@ -432,24 +432,12 @@ class SimpleActionServer(EventEmitterMixin):
         LOGGER.info("Action server {} setting current goal to SUCCEEDED".format(self.server_name))
 
         with self._lock:
-
-            self.status_message["status_list"] = [
-                dict(
-                    goal_id=self.current_goal["goal_id"],
-                    status=GoalStatus.SUCCEEDED)
-            ]
+            status = dict(goal_id=self.current_goal["goal_id"], status=GoalStatus.SUCCEEDED)
+            self.status_message["status_list"] = [status]
             self._publish_status()
             self.status_message["status_list"] = []
 
-            result_message = Message(
-                {
-                    "status": {
-                        "goal_id": self.current_goal["goal_id"],
-                        "status": GoalStatus.SUCCEEDED
-                    },
-                    "result": result
-                }
-            )
+            result_message = Message({"status": status, "result": result})
             self.result_publisher.publish(result_message)
 
             if self.next_goal:
@@ -481,23 +469,12 @@ class SimpleActionServer(EventEmitterMixin):
         LOGGER.info("Action server {} preempting current goal".format(self.server_name))
 
         with self._lock:
-
-            self.status_message["status_list"] = [
-                dict(
-                    goal_id=self.current_goal["goal_id"],
-                    status=GoalStatus.PREEMPTED)
-            ]
+            status = dict(goal_id=self.current_goal["goal_id"], status=GoalStatus.PREEMPTED)
+            self.status_message["status_list"] = [status]
             self._publish_status()
             self.status_message["status_list"] = []
 
-            result_message = Message(
-                {
-                    "status": {
-                        "goal_id": self.current_goal["goal_id"],
-                        "status": GoalStatus.PREEMPTED
-                    }
-                }
-            )
+            result_message = Message({"status": status})
             self.result_publisher.publish(result_message)
 
             if self.next_goal:

--- a/tests/test_actionlib.py
+++ b/tests/test_actionlib.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import time
 
 from roslibpy import Ros
-from roslibpy.actionlib import ActionClient, Goal, SimpleActionServer, GoalStatus
+from roslibpy.actionlib import ActionClient, Goal, GoalStatus, SimpleActionServer
 
 
 def test_action_success():

--- a/tests/test_actionlib.py
+++ b/tests/test_actionlib.py
@@ -1,0 +1,61 @@
+from __future__ import print_function
+
+import time
+
+from roslibpy import Ros
+from roslibpy.actionlib import ActionClient, Goal, SimpleActionServer, GoalStatus
+
+
+def test_action_success():
+    ros = Ros("127.0.0.1", 9090)
+    ros.run()
+
+    server = SimpleActionServer(ros, "/test_action", "actionlib/TestAction")
+
+    def execute(goal):
+        server.set_succeeded({"result": goal["goal"]})
+
+    server.start(execute)
+
+    client = ActionClient(ros, "/test_action", "actionlib/TestAction")
+    goal = Goal(client, {"goal": 13})
+
+    goal.send()
+    result = goal.wait(10)
+
+    assert result["result"] == 13
+    assert goal.status["status"] == GoalStatus.SUCCEEDED
+
+    client.dispose()
+    time.sleep(2)
+    ros.close()
+
+
+def test_action_preemt():
+    ros = Ros("127.0.0.1", 9090)
+    ros.run()
+
+    server = SimpleActionServer(ros, "/test_action", "actionlib/TestAction")
+
+    def execute(_goal):
+        while not server.is_preempt_requested():
+            time.sleep(0.1)
+        server.set_preempted()
+
+    server.start(execute)
+
+    client = ActionClient(ros, "/test_action", "actionlib/TestAction")
+    goal = Goal(client, {"goal": 13})
+
+    goal.send()
+    time.sleep(0.5)
+    goal.cancel()
+
+    result = goal.wait(10)
+
+    assert result["result"] == 0
+    assert goal.status["status"] == GoalStatus.PREEMPTED
+
+    client.dispose()
+    time.sleep(2)
+    ros.close()


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Hi :)

I saw the open issue [#95](https://github.com/gramaziokohler/roslibpy/issues/95) and decided to fix the reported bug.
As reported, an error occurs when you try to run the [ROS action example](https://roslibpy.readthedocs.io/en/latest/examples.html#actions) from the documentation.
The proposed changes solve the said bug.  

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
         **NOTE**: One test is failing. However, I checked the ```main``` branch and that same test also failed there so I don't think it's related to my changes.
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

### Some remarks

After some debugging, I think I've found the origin of the problem.

It seems that the action client was receiving the result all along! However, the client's ```wait``` function always raises the shown exception because no status message is being published with adequate SUCCEEDED and PREEMPTED status codes by the action server. Since these messages are not published, the client's ```is_finished``` property never returns ```True``` and therefore the client keeps on waiting for the result (even after having received it).

After ensuring that proper status messages are published inside the server's ```set_succeeded``` and ```set_preempted``` functions, the following now happens when running the documentation example:

```bash
$ python3 ros-action-client.py 
[0, 1, 1]
[0, 1, 1, 2]
[0, 1, 1, 2, 3]
[0, 1, 1, 2, 3, 5]
[0, 1, 1, 2, 3, 5, 8]
[0, 1, 1, 2, 3, 5, 8, 13]
[0, 1, 1, 2, 3, 5, 8, 13, 21]
Result: [0, 1, 1, 2, 3, 5, 8, 13, 21]
```

Checking published messages with ```rostopic echo``` the following message are now detected: 

```
---
header: 
  seq: 6
  stamp: 
    secs: 1670093700
    nsecs: 961247206
  frame_id: ''
status_list: 
  - 
    goal_id: 
      stamp: 
        secs: 0
        nsecs:         0
      id: "goal_0.6644001782365995_1670093700955"
    status: 3
    text: ''
---
```

No such message was shown before.

Please let me know what you think of these changes.
If they seem okay to you, I can implement some unit tests later :)