### PR TITLE
Remove usage of `raise Exception` in favor of more specific exception types

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ Authors
 * Beverly Lytle `@beverlylytle <https://github.com/beverlylytle>`_
 * Alexis Jeandeau `@jeandeaual <https://github.com/jeandeaual>`_
 * Hiroyuki Obinata `@obi-t4 <https://github.com/obi-t4>`_
+* Domenic Rodriguez `@DomenicP <https://github.com/DomenicP>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Unreleased
 * Switched to ``black`` for python code formatting.
 * Fix incompatible settings between ``black`` and ``flake8``.
 * Updated Github Actions workflows to remove python 3.6 builds.
+* Replaced occurrences of ``raise Exception`` with more specific ``Exception`` subclasses.
 
 **Fixed**
 

--- a/src/roslibpy/actionlib.py
+++ b/src/roslibpy/actionlib.py
@@ -136,7 +136,7 @@ class Goal(EventEmitterMixin):
             Result of the goal.
         """
         if not self.wait_result.wait(timeout):
-            raise Exception("Goal failed to receive result")
+            raise TimeoutError("Goal failed to receive result")
 
         return self.result
 
@@ -226,7 +226,7 @@ class ActionClient(EventEmitterMixin):
         self.wait_status = threading.Event()
 
         if not self.wait_status.wait(DEFAULT_CONNECTION_TIMEOUT):
-            raise Exception("Action client failed to connect, no status received.")
+            raise TimeoutError("Action client failed to connect, no status received.")
 
     def _on_status_message(self, message):
         self.wait_status.set()

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -232,7 +232,7 @@ class TwistedEventLoopManager(object):
         Raises:
             An exception.
         """
-        raise Exception("No service response received")
+        raise TimeoutError("No service response received")
 
     def get_inner_callback(self, result_placeholder):
         """Get the callback which, when called, provides result_placeholder with the result.

--- a/src/roslibpy/core.py
+++ b/src/roslibpy/core.py
@@ -310,6 +310,12 @@ class Topic(object):
         self._advertise_id = None
 
 
+class ServiceException(Exception):
+    """Exception that is thrown when a service call fails."""
+
+    pass
+
+
 class Service(object):
     """Client/server of ROS services.
 
@@ -382,7 +388,7 @@ class Service(object):
         # Blocking mode
         call_results = self.ros.call_sync_service(message, timeout)
         if "exception" in call_results:
-            raise Exception(call_results["exception"])
+            raise ServiceException(call_results["exception"])
 
         return call_results["result"]
 

--- a/src/roslibpy/ros.py
+++ b/src/roslibpy/ros.py
@@ -96,7 +96,7 @@ class Ros(object):
         self.factory.on_ready(lambda _: wait_connect.set())
 
         if not wait_connect.wait(timeout):
-            raise Exception("Failed to connect to ROS")
+            raise TimeoutError("Failed to connect to ROS")
 
     def run_forever(self):
         """Kick-starts a blocking loop to wait for events.


### PR DESCRIPTION
Currently roslibpy has a number of places where `Exception` is directly raised instead of a more specific error type. This means that users of the library have to use `except:` or `except Exception:` when calling methods that may raise an exception, which is not generally regarded to be a good Python practice. For example,

```python
ros = roslibpy.Ros(host=..., port=...)

...

try:
    ros.run()
except Exception:  # pylint: disable=broad-except
    # roslibpy will attempt to connect immediately, but the robot may not be
    # present. This is fine, we can just ignore it.
    pass
```

Note the pylint disable message required for the `broad-except` violation.

One easy way to fix this is to raise more specific error types instead of raising `Exception` directly. This PR goes through and eliminates all direct occurrences of `raise Exception` from the library code (there are still a few in the tests). In a lot of these cases the exception was being raised due to a timeout so switching to `TimeoutError` seemed reasonable. I also introduced the `ServiceException` class to be raised when a blocking service call fails.

This change should be backwards compatible since any code that was catching `Exception` should also catch subclasses of `Exception`.

Open to discussion or suggestions around this PR since there are a number of ways to approach this topic.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
