### PR TITLE
add authentication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Unreleased
 
 **Added**
 
+* Added authentication functionality described in [rosauth](http://wiki.ros.org/rosauth).
+
 **Changed**
 
 **Fixed**

--- a/src/roslibpy/ros.py
+++ b/src/roslibpy/ros.py
@@ -555,6 +555,35 @@ class Ros(object):
 
         return output
 
+    def authenticate(self, mac, client, dest, rand, t, level, end):
+        """Sends an authorization request to the server.
+
+        Note:
+            Sends authentication on connection.
+
+        Args:
+            mac (:obj:`str`): MAC (hash) string given by the trusted source.
+            client (:obj:`str`): IP of the client.
+            dest (:obj:`str`): IP of the destination.
+            rand (:obj:`str`): Random string given by the trusted source.
+            t (:obj:`float`): Time of the authorization request.
+            level (:obj:`str`): User level as a string given by the client.
+            end (:obj:`float`): End time of the client's session.
+        """
+        def _ready_callback(*args):
+            self.send_on_ready(Message({
+                'op' : 'auth',
+                'mac' : mac,
+                'client' : client,
+                'dest' : dest,
+                'rand' : rand,
+                't' : t,
+                'level' : level,
+                'end' : end,
+            }))
+
+        self.on('ready', _ready_callback)
+
 
 if __name__ == "__main__":
     FORMAT = "%(asctime)-15s [%(levelname)s] %(message)s"


### PR DESCRIPTION
<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This is basically a port for the [authenticate function in roslibjs](https://robotwebtools.github.io/roslibjs/core_Ros.js.html#line109). It enables the example in [rosauth](http://wiki.ros.org/rosauth) to be performed on `roslibpy`, as well as fixes #86.

Following the example in [rosauth](http://wiki.ros.org/rosauth), one would call `authenticate()` before calling `run()`:
```python
import roslibpy

auth = {'mac' : '19d9d2166799f1ffd6fee6379f957502aff8716bfebc8cc8b3bac57ade14441bb9678be89d0a7eec9c81291f854d754d7a4de2278bede56f162c2faeb468c68a',
    'client' : 'client',
    'dest' : 'dest',
    'rand' : 'rand',
    't' : 0,
    'level' : 'level',
    'end' : 0
}

client = roslibpy.Ros(host='localhost', port=9090)
client.authenticate(**auth) # need for authentication is specified here. ** is used to unpack the dictionary.
client.run()

# subscriber example.
listener = roslibpy.Topic(client, '/chatter', 'std_msgs/String')
listener.subscribe(lambda message: print('Heard talking: ' + message['data']))

try:
    while True:
        pass
except KeyboardInterrupt:
    client.terminate()
```
On the `rosbridge_server` terminal one would see:
```text
2023-08-29 13:55:43+0000 [-] [INFO] [1693317343.325643]: Client connected.  1 clients total.
2023-08-29 13:55:43+0000 [-] [INFO] [1693317343.326674]: Awaiting proper authentication...
2023-08-29 13:55:43+0000 [-] [INFO] [1693317343.329715]: Client 1 has authenticated.
```
I am unsure what tests and documentation to include for this change.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
