### PR TITLE
Removed seq field from Header messages as they are no longer supported in ROS2

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,3 +10,4 @@ Authors
 * Hiroyuki Obinata `@obi-t4 <https://github.com/obi-t4>`_
 * Pedro Pereira `@MisterOwlPT <https://github.com/MisterOwlPT>`_
 * Domenic Rodriguez `@DomenicP <https://github.com/DomenicP>`_
+* Ilia Baranov `@iliabaranov <https://github.com/iliabaranov>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Unreleased
 
 **Fixed**
 
+* Removed seq field from the header message type, as this is no longer supported in ROS2
+
 **Deprecated**
 
 **Removed**

--- a/src/roslibpy/core.py
+++ b/src/roslibpy/core.py
@@ -50,9 +50,8 @@ class Message(UserDict):
 class Header(UserDict):
     """Represents a message header of the ROS type std_msgs/Header."""
 
-    def __init__(self, seq=None, stamp=None, frame_id=None):
+    def __init__(self, stamp=None, frame_id=None):
         self.data = {}
-        self.data["seq"] = seq
         self.data["stamp"] = Time(stamp["secs"], stamp["nsecs"]) if stamp else None
         self.data["frame_id"] = frame_id
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,14 +27,14 @@ def test_is_zero():
 
 
 def test_header_ctor_supports_time():
-    header = Header(seq=1, stamp=Time.from_sec(REF_FLOAT_SECS_TIME))
+    header = Header(stamp=Time.from_sec(REF_FLOAT_SECS_TIME))
     assert header["stamp"]["secs"] == 1610122759
     assert header["stamp"]["secs"] == header["stamp"].secs
     assert header["stamp"].to_sec() == REF_FLOAT_SECS_TIME
 
 
 def test_header_ctor_supports_dict():
-    header = Header(seq=1, stamp=dict(secs=1610122759, nsecs=677661895))
+    header = Header(stamp=dict(secs=1610122759, nsecs=677661895))
     assert header["stamp"]["secs"] == 1610122759
     assert header["stamp"]["secs"] == header["stamp"].secs
     assert header["stamp"].to_sec() == REF_FLOAT_SECS_TIME

--- a/tests/test_topic.py
+++ b/tests/test_topic.py
@@ -69,7 +69,7 @@ def test_topic_with_header():
 
     def start_sending():
         for i in range(3):
-            msg = dict(header=Header(seq=i, stamp=Time.now(), frame_id="base"), point=dict(x=0.0, y=1.0, z=2.0))
+            msg = dict(header=Header(stamp=Time.now(), frame_id="base"), point=dict(x=0.0, y=1.0, z=2.0))
             publisher.publish(Message(msg))
             time.sleep(0.1)
 


### PR DESCRIPTION
As mentioned here: https://github.com/gramaziokohler/roslibpy/issues/109

Header message in ROS2 no longer supports the seq field.
Hence I have removed it, and modified the tests to ensure the correct behavior is followed.

Followed the steps here:
https://github.com/gramaziokohler/roslibpy/blob/f60cf8f3c385985e59bbb8967caf6ec5c8355c3d/CONTRIBUTING.rst

Unsure this is a breaking change? I suspect so, but really it makes the header message work properly now, where it failed before.

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [X] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ X] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [X] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [X] I have added tests that prove my fix is effective or that my feature works.

