### PR TITLE
Add websocket header support to the ROS-client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Unreleased
 
 **Added**
 
+* Added websocket header support to the ROS-client.
+
 **Changed**
 
 **Fixed**

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,4 +10,5 @@ pydocstyle
 pytest>=6.0
 sphinx >=3.4
 twine
+websockets >= 12.0
 -e .

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -23,16 +23,9 @@ LOGGER = logging.getLogger("roslibpy")
 class AutobahnRosBridgeProtocol(RosBridgeProtocol, WebSocketClientProtocol):
     def __init__(self, *args, **kwargs):
         super(AutobahnRosBridgeProtocol, self).__init__(*args, **kwargs)
-        self.headers = {}
 
     def onConnect(self, response):
         LOGGER.debug("Server connected: %s", response.peer)
-
-    def getHandshakeRequestHeaders(self):
-        headers = super(AutobahnRosBridgeProtocol, self).getHandshakeRequestHeaders()
-        for key, value in self.headers.items():
-            headers.append((key, value))
-        return headers
 
     def onOpen(self):
         LOGGER.info("Connection to ROS ready.")
@@ -69,19 +62,12 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
 
     protocol = AutobahnRosBridgeProtocol
 
-    def __init__(self, *args, headers=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         super(AutobahnRosBridgeClientFactory, self).__init__(*args, **kwargs)
-        self.headers = headers or {}
         self._proto = None
         self._manager = None
         self.connector = None
         self.setProtocolOptions(closeHandshakeTimeout=5)
-
-    def buildProtocol(self, addr):
-        proto = self.protocol()
-        proto.factory = self
-        proto.headers = self.headers
-        return proto
 
     def connect(self):
         """Establish WebSocket connection to the ROS server defined for this factory."""

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -23,9 +23,16 @@ LOGGER = logging.getLogger("roslibpy")
 class AutobahnRosBridgeProtocol(RosBridgeProtocol, WebSocketClientProtocol):
     def __init__(self, *args, **kwargs):
         super(AutobahnRosBridgeProtocol, self).__init__(*args, **kwargs)
+        self.headers = {}
 
     def onConnect(self, response):
         LOGGER.debug("Server connected: %s", response.peer)
+
+    def getHandshakeRequestHeaders(self):
+        headers = super(AutobahnRosBridgeProtocol, self).getHandshakeRequestHeaders()
+        for key, value in self.headers.items():
+            headers.append((key, value))
+        return headers
 
     def onOpen(self):
         LOGGER.info("Connection to ROS ready.")
@@ -62,12 +69,19 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
 
     protocol = AutobahnRosBridgeProtocol
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, headers=None, **kwargs):
         super(AutobahnRosBridgeClientFactory, self).__init__(*args, **kwargs)
+        self.headers = headers or {}
         self._proto = None
         self._manager = None
         self.connector = None
         self.setProtocolOptions(closeHandshakeTimeout=5)
+
+    def buildProtocol(self, addr):
+        proto = self.protocol()
+        proto.factory = self
+        proto.headers = self.headers
+        return proto
 
     def connect(self):
         """Establish WebSocket connection to the ROS server defined for this factory."""

--- a/src/roslibpy/ros.py
+++ b/src/roslibpy/ros.py
@@ -32,12 +32,13 @@ class Ros(object):
         host (:obj:`str`): Name or IP address of the ROS bridge host, e.g. ``127.0.0.1``.
         port (:obj:`int`): ROS bridge port, e.g. ``9090``.
         is_secure (:obj:`bool`): ``True`` to use a secure web sockets connection, otherwise ``False``.
+        headers (:obj:`dict`): Additional headers to include in the WebSocket connection.
     """
 
-    def __init__(self, host, port=None, is_secure=False):
+    def __init__(self, host, port=None, is_secure=False, headers=None):
         self._id_counter = 0
         url = RosBridgeClientFactory.create_url(host, port, is_secure)
-        self.factory = RosBridgeClientFactory(url)
+        self.factory = RosBridgeClientFactory(url, headers=headers)
         self.is_connecting = False
         self.connect()
 

--- a/tests/test_ws_headers.py
+++ b/tests/test_ws_headers.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+import threading
+import time
+
+from autobahn.twisted.websocket import WebSocketServerProtocol, WebSocketServerFactory
+from twisted.internet import reactor
+
+from roslibpy import Ros
+
+headers = {
+    'cookie': 'token=rosbridge',
+    'authorization': 'Some auth'
+}
+
+class TestWebSocketServerProtocol(WebSocketServerProtocol):
+    def onConnect(self, request):
+        for key, value in headers.items():
+            assert request.headers.get(key) == value, f"Header {key} did not match expected value {value}"
+        self.factory.context['wait'].set()
+
+    def onOpen(self):
+        self.sendClose()
+
+def run_server(context):
+    factory = WebSocketServerFactory()
+    factory.protocol = TestWebSocketServerProtocol
+    factory.context = context
+
+    reactor.listenTCP(9000, factory)
+    reactor.run(installSignalHandlers=False)
+
+def run_client():
+    client = Ros('127.0.0.1', 9000, headers=headers)
+    client.run()
+    client.close()
+
+def test_websocket_headers():
+    context = dict(wait=threading.Event())
+
+    server_thread = threading.Thread(target=run_server, args=(context,))
+    server_thread.start()
+
+    time.sleep(1)  # Give the server time to start
+
+    client_thread = threading.Thread(target=run_client)
+    client_thread.start()
+
+    if not context["wait"].wait(10):
+        raise Exception("Headers were not as expected")
+
+    client_thread.join()
+    reactor.callFromThread(reactor.stop)
+    server_thread.join()
+
+if __name__ == "__main__":
+    test_websocket_headers()


### PR DESCRIPTION
### Description

Some device that I am using has a websocket available that is protected with a token. This token needs to be passed via the websocket connection header. This PR adds websocket header support to the ROS-client.

The headers can be added to the ROS-client like this, also see `test_ws_headers.py`:
```python

headers = {
    'cookie': 'token=rosbridge',
    'authorization': 'Some auth'
}

client = Ros('127.0.0.1', 9000, headers=headers)
```

### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

I don't see a reason why this couldn't be backwards compatible, but I could be wrong.

### Checklist

- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

### Questions

* Is this desired for this library? Otherwise I will continue to use my fork.
* Is the test in the right spot? It is independent of ROS-version so this seemed fine.
* I am not familiar with autobahn and twisted so let me know if this should be accomplished in another way.
* Should the passing of headers be more explicit? Now it just happens via the **kwargs of `RosBridgeClientFactory`.
