### PR TITLE
Added ROS2 ActionClient w/ limited functionality

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Authors
 * Pedro Pereira `@MisterOwlPT <https://github.com/MisterOwlPT>`_
 * Domenic Rodriguez `@DomenicP <https://github.com/DomenicP>`_
 * Ilia Baranov `@iliabaranov <https://github.com/iliabaranov>`_
+* Dani Martinez `@danmartzla <https://github.com/danmartzla>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Unreleased
 ----------
 
 **Added**
+* Added ROS2 action client object with limited capabilities ``roslibpy.ActionClient``.
 
 **Changed**
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -246,6 +246,13 @@ This example is very simplified and uses the :meth:`roslibpy.actionlib.Goal.wait
 function to make the code easier to read as an example. A more robust way to handle
 results is to hook up to the ``result`` event with a callback.
 
+For action clients to deal with ROS2 action servers, check the following example: 
+
+.. literalinclude :: files/ros2-action-client.py
+   :language: python
+
+* :download:`ros2-action-client.py <files/ros2-action-client.py>`
+
 Querying ROS API
 ----------------
 

--- a/docs/files/ros2-action-client.py
+++ b/docs/files/ros2-action-client.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+import roslibpy
+
+client = roslibpy.Ros(host='localhost', port=9090)
+client.run()
+
+action_client = roslibpy.ActionClient(client,
+                                      '/fibonacci',
+                                      'custom_action_interfaces/action/Fibonacci')
+
+def result_callback(msg):
+    print('Action result:',msg['sequence'])
+
+def feedback_callback(msg):
+    print('Action feedback:',msg['partial_sequence'])
+
+def fail_callback(msg):
+    print('Action failed:',msg)
+
+goal_id = action_client.send_goal(roslibpy.ActionGoal({'order': 8}),
+                                  result_callback,
+                                  feedback_callback,
+                                  fail_callback)
+
+goal.on('feedback', lambda f: print(f['sequence']))
+goal.send()
+result = goal.wait(10)
+action_client.dispose()
+
+print('Result: {}'.format(result['sequence']))

--- a/docs/files/ros2-action-client.py
+++ b/docs/files/ros2-action-client.py
@@ -1,5 +1,9 @@
 from __future__ import print_function
 import roslibpy
+import time
+
+
+global result
 
 client = roslibpy.Ros(host='localhost', port=9090)
 client.run()
@@ -7,9 +11,11 @@ client.run()
 action_client = roslibpy.ActionClient(client,
                                       '/fibonacci',
                                       'custom_action_interfaces/action/Fibonacci')
+result = None
 
 def result_callback(msg):
-    print('Action result:',msg['sequence'])
+    global result
+    result = msg['result']
 
 def feedback_callback(msg):
     print('Action feedback:',msg['partial_sequence'])
@@ -22,9 +28,7 @@ goal_id = action_client.send_goal(roslibpy.ActionGoal({'order': 8}),
                                   feedback_callback,
                                   fail_callback)
 
-goal.on('feedback', lambda f: print(f['sequence']))
-goal.send()
-result = goal.wait(10)
-action_client.dispose()
-
-print('Result: {}'.format(result['sequence']))
+while result == None:
+    time.sleep(1)
+    
+print('Action result: {}'.format(result['sequence']))

--- a/src/roslibpy/__init__.py
+++ b/src/roslibpy/__init__.py
@@ -82,6 +82,20 @@ model via :class:`Services <Service>`.
 .. autoclass:: ServiceResponse
    :members:
 
+Actions
+--------
+
+An Action client for ROS2 Actions can be used by managing goal/feedback/result
+messages via :class:`ActionClient <ActionClient>`.
+
+.. autoclass:: ActionClient
+   :members:
+.. autoclass:: ActionGoal
+   :members:
+.. autoclass:: ActionFeedback
+   :members:
+.. autoclass:: ActionResult
+   :members:
 
 Parameter server
 ----------------
@@ -114,6 +128,10 @@ from .__version__ import (
     __version__,
 )
 from .core import (
+    ActionClient,
+    ActionFeedback,
+    ActionGoal,
+    ActionResult,
     Header,
     Message,
     Param,
@@ -140,6 +158,10 @@ __all__ = [
     "Service",
     "ServiceRequest",
     "ServiceResponse",
+    "ActionClient",
+    "ActionGoal",
+    "ActionFeedback",
+    "ActionResult",
     "Time",
     "Topic",
     "set_rosapi_timeout",

--- a/src/roslibpy/comm/comm.py
+++ b/src/roslibpy/comm/comm.py
@@ -3,7 +3,13 @@ from __future__ import print_function
 import json
 import logging
 
-from roslibpy.core import Message, MessageEncoder, ServiceResponse
+from roslibpy.core import (
+    ActionFeedback,
+    ActionResult,
+    Message,
+    MessageEncoder,
+    ServiceResponse,
+)
 
 LOGGER = logging.getLogger("roslibpy")
 
@@ -22,19 +28,23 @@ class RosBridgeProtocol(object):
         super(RosBridgeProtocol, self).__init__(*args, **kwargs)
         self.factory = None
         self._pending_service_requests = {}
+        self._pending_action_requests = {}
         self._message_handlers = {
             "publish": self._handle_publish,
             "service_response": self._handle_service_response,
             "call_service": self._handle_service_request,
+            "send_action_goal": self._handle_action_request,  # TODO: action server
+            "cancel_action_goal": self._handle_action_cancel,  # TODO: action server
+            "action_feedback": self._handle_action_feedback,
+            "action_result": self._handle_action_result,
+            "status": None,  # TODO: add handlers for op: status
         }
-        # TODO: add handlers for op: status
 
     def on_message(self, payload):
         message = Message(json.loads(payload.decode("utf8")))
         handler = self._message_handlers.get(message["op"], None)
         if not handler:
             raise RosBridgeException('No handler registered for operation "%s"' % message["op"])
-
         handler(message)
 
     def send_ros_message(self, message):
@@ -106,3 +116,55 @@ class RosBridgeProtocol(object):
             raise ValueError("Expected service name missing in service request")
 
         self.factory.emit(message["service"], message)
+
+    def send_ros_action_goal(self, message, resultback, feedback, errback):
+        """Initiate a ROS action request by sending a goal through the ROS Bridge.
+
+        Args:
+        message (:class:`.Message`): ROS Bridge Message containing the action request.
+        callback: Callback invoked on receiving result.
+        feedback: Callback invoked when receiving feedback from action server.
+        errback: Callback invoked on error.
+        """
+        request_id = message["id"]
+        self._pending_action_requests[request_id] = (resultback, feedback, errback)
+
+        json_message = json.dumps(dict(message), cls=MessageEncoder).encode("utf8")
+        LOGGER.debug("Sending ROS action goal request: %s", json_message)
+
+        self.send_message(json_message)
+
+    def _handle_action_request(self, message):
+        if "action" not in message:
+            raise ValueError("Expected action name missing in action request")
+        raise RosBridgeException('Action server capabilities not yet implemented')
+
+    def _handle_action_cancel(self, message):
+        if "action" not in message:
+            raise ValueError("Expected action name missing in action request")
+        raise RosBridgeException('Action server capabilities not yet implemented')
+
+    def _handle_action_feedback(self, message):
+        if "action" not in message:
+            raise ValueError("Expected action name missing in action feedback")
+
+        request_id = message["id"]
+        _, feedback, _ = self._pending_action_requests.get(request_id, None)
+        feedback(ActionFeedback(message["values"]))
+
+    def _handle_action_result(self, message):
+        request_id = message["id"]
+        action_handlers = self._pending_action_requests.get(request_id, None)
+
+        if not action_handlers:
+            raise RosBridgeException('No handler registered for action request ID: "%s"' % request_id)
+
+        resultback, _ , errback = action_handlers
+        del self._pending_action_requests[request_id]
+
+        if "result" in message and message["result"] is False:
+            if errback:
+                errback(message["values"])
+        else:
+            if resultback:
+                resultback(ActionResult(message["values"]))

--- a/src/roslibpy/core.py
+++ b/src/roslibpy/core.py
@@ -575,6 +575,7 @@ class ActionClient(object):
 
     def cancel_goal(self, goal_id):
         """ Cancel an ongoing action.
+            NOTE: Async cancelation is not yet supported on rosbridge (rosbridge_suite issue #909)
 
             Args:
             goal_id: Goal ID returned from "send_goal()"
@@ -587,6 +588,7 @@ class ActionClient(object):
             }
         )
         self.ros.send_on_ready(message)
+        # Remove message_id from RosBridgeProtocol._pending_action_requests in comms.py?
 
 
 class Param(object):

--- a/src/roslibpy/core.py
+++ b/src/roslibpy/core.py
@@ -522,12 +522,12 @@ class Service(object):
 
 
 class ActionClient(object):
-    """Action Client of ROS2 services.
+    """Action Client of ROS2 actions.
 
     Args:
         ros (:class:`.Ros`): Instance of the ROS connection.
-        name (:obj:`str`): Service name, e.g. ``/add_two_ints``.
-        service_type (:obj:`str`): Service type, e.g. ``rospy_tutorials/AddTwoInts``.
+        name (:obj:`str`): Service name, e.g. ``/fibonacci``.
+        action_type (:obj:`str`): Action type, e.g. ``rospy_tutorials/fibonacci``.
     """
 
     def __init__(self, ros, name, action_type, reconnect_on_close=True):
@@ -539,23 +539,20 @@ class ActionClient(object):
         self._is_advertised = False
         self.reconnect_on_close = reconnect_on_close
 
-    def send_goal(self, goal, result_back, feedback_back, failed_back):
+    def send_goal(self, goal, resultback, feedback, errback):
         """ Start a service call.
 
             Note:
-            The service can be used either as blocking or non-blocking.
-            If the ``callback`` parameter is ``None``, then the call will
-            block until receiving a response. Otherwise, the service response
-            will be returned in the callback.
+            The action client is non-blocking.
 
             Args:
             request (:class:`.ServiceRequest`): Service request.
-            callback: Callback invoked on successful execution.
+            resultback: Callback invoked on receiving action result.
+            feedback: Callback invoked on receiving action feedback.
             errback: Callback invoked on error.
-            timeout: Timeout for the operation, in seconds. Only used if blocking.
 
             Returns:
-            object: Service response if used as a blocking call, otherwise ``None``.
+            object: goal ID if successfull, otherwise ``None``.
         """
         if self._is_advertised:
             return
@@ -573,10 +570,15 @@ class ActionClient(object):
             }
         )
 
-        self.ros.call_async_action(message,  result_back, feedback_back, failed_back)
+        self.ros.call_async_action(message,  resultback, feedback, errback)
         return action_goal_id
 
     def cancel_goal(self, goal_id):
+        """ Cancel an ongoing action.
+
+            Args:
+            goal_id: Goal ID returned from "send_goal()"
+        """
         message = Message(
             {
                 "op": "cancel_action_goal",

--- a/src/roslibpy/ros.py
+++ b/src/roslibpy/ros.py
@@ -272,6 +272,24 @@ class Ros(object):
 
         self.factory.on_ready(_send_internal)
 
+    def call_async_action(self, message, resultback, feedback, errback):
+        """Send a action request to ROS once the connection is established.
+
+        If a connection to ROS is already available, the request is sent immediately.
+
+        Args:
+            message (:class:`.Message`): ROS Bridge Message containing the request.
+            resultback: Callback invoked on successful execution.
+            feedback:
+            errback: Callback invoked on error.
+        """
+
+        def _send_internal(proto):
+            proto.send_ros_action_goal(message, resultback, feedback, errback)
+            return proto
+
+        self.factory.on_ready(_send_internal)
+
     def set_status_level(self, level, identifier):
         level_message = Message({"op": "set_level", "level": level, "id": identifier})
 

--- a/src/roslibpy/ros.py
+++ b/src/roslibpy/ros.py
@@ -280,7 +280,7 @@ class Ros(object):
         Args:
             message (:class:`.Message`): ROS Bridge Message containing the request.
             resultback: Callback invoked on successful execution.
-            feedback:
+            feedback: Callback invoked on receiving action feedback.
             errback: Callback invoked on error.
         """
 


### PR DESCRIPTION

Added the **roslibpy.ActionClient** object to send actions goals to ROS2-based systems.
This implementation has limited capabilities (related to #909) such as:
* Goal cancelation is not functional.
* Goal rejection/acceptance are not being notified to the Action client.


### What type of change is this?

- [ ] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist
- [x] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)
