### PR TITLE
Fix reconnection bug on Twisted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Unreleased
 
 **Fixed**
 
+* Fixed reconnection on the Twisted transport failing after a connection had
+  been idle for more than a few seconds: ``connect`` now schedules the
+  connection through the reactor thread so an idle reactor is woken to service
+  it (previously the new connector was added from another thread and the
+  reactor, blocked in ``select()``, never noticed it).
+
 **Deprecated**
 
 **Removed**

--- a/src/roslibpy/comm/comm_autobahn.py
+++ b/src/roslibpy/comm/comm_autobahn.py
@@ -71,6 +71,16 @@ class AutobahnRosBridgeClientFactory(EventEmitterMixin, ReconnectingClientFactor
 
     def connect(self):
         """Establish WebSocket connection to the ROS server defined for this factory."""
+        # Route the connection setup through the reactor thread. Calling
+        # ``connectWS`` directly only happens to work while the reactor is busy;
+        # once it is idle (e.g. more than ``closeHandshakeTimeout`` seconds after
+        # a previous disconnect) it sits blocked in ``select()`` and never
+        # notices a connector added from another thread, so the connection times
+        # out. ``callFromThread`` wakes it, and is also safe before the reactor
+        # has started (the call is queued and runs once it does).
+        reactor.callFromThread(self._connect)
+
+    def _connect(self):
         self.connector = connectWS(self)
 
     @property


### PR DESCRIPTION
After a disconnect, if you reconnect within 5 seconds, everything works, but after that, the service gives up. Here's a fix for it.

This should address the bugs on https://github.com/RobotWebTools/roslibpy/issues/97#issuecomment-3467621563, https://github.com/RobotWebTools/roslibpy/issues/98 and https://github.com/RobotWebTools/roslibpy/issues/121

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X ] I added a line to the `CHANGELOG.rst` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke check`).
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
